### PR TITLE
Add ability to install yarn v2+

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 
 Yarn plugin for the [asdf][1] version manager.
 
-> 💡 **Note:** This plugin validates package authenticity via [`gpg`][2].
+> 💡 **Note:** This plugin validates package authenticity via [`gpg`][2] only for yarn v1.
+> v2 and later versions are downloaded as single js file which doesn't have any signatures
 
 ## Requirements
 
@@ -17,23 +18,6 @@ If one of the commands needed is unavailable, it will let you know.
 asdf plugin-add yarn
 asdf install yarn latest
 ```
-
-## Looking for Yarn v2?
-
-In v2.x, Yarn introduced its own version manager which can only be
-configured on a per-project basis. There is no "global install" variation
-of the v2.x release line.
-
-To use Yarn v2.x in your project:
-
- 1. Use this plugin to set the v1.x Yarn version for the project
-    (e.g: `asdf local yarn 1.22.10`).
-
- 2. Use Yarn to set the v2.x Yarn version for the project
-    (e.g: `yarn set version 2.4.1`).
-
-After these two steps, your project will be configured to use Yarn v2.x.
-If you do not wish to opt in to v2.x, then step 1 is all you need.
 
 [1]: https://asdf-vm.com/
 [2]: https://www.openpgp.org/

--- a/bin/install
+++ b/bin/install
@@ -8,7 +8,7 @@ asdf_yarn_fail() {
   exit 1
 }
 
-asdf_yarn_keyring() {
+asdf_yarn_v1_keyring() {
   local YARN_KEYRING="${ASDF_DATA_DIR:-$HOME/.asdf}/keyrings/yarn"
 
   if [ ! -d "${YARN_KEYRING}" ]; then
@@ -19,7 +19,7 @@ asdf_yarn_keyring() {
   echo "${YARN_KEYRING}"
 }
 
-asdf_yarn_download_wget() {
+asdf_yarn_v1_download_wget() {
   # Download archive
   wget -O "yarn-v${ASDF_INSTALL_VERSION}.tar.gz" "https://classic.yarnpkg.com/downloads/${ASDF_INSTALL_VERSION}/yarn-v${ASDF_INSTALL_VERSION}.tar.gz"
 
@@ -27,10 +27,10 @@ asdf_yarn_download_wget() {
   wget -O "yarn-v${ASDF_INSTALL_VERSION}.tar.gz.asc" "https://classic.yarnpkg.com/downloads/${ASDF_INSTALL_VERSION}/yarn-v${ASDF_INSTALL_VERSION}.tar.gz.asc"
 
   # Download and import signing key
-  wget -q -O - "https://dl.yarnpkg.com/debian/pubkey.gpg" | GNUPGHOME="$(asdf_yarn_keyring)" gpg --import
+  wget -q -O - "https://dl.yarnpkg.com/debian/pubkey.gpg" | GNUPGHOME="$(asdf_yarn_v1_keyring)" gpg --import
 }
 
-asdf_yarn_download_curl() {
+asdf_yarn_v1_download_curl() {
   # Download archive
   curl -sSL -o "yarn-v${ASDF_INSTALL_VERSION}.tar.gz" "https://classic.yarnpkg.com/downloads/${ASDF_INSTALL_VERSION}/yarn-v${ASDF_INSTALL_VERSION}.tar.gz"
 
@@ -38,29 +38,29 @@ asdf_yarn_download_curl() {
   curl -sSL -o "yarn-v${ASDF_INSTALL_VERSION}.tar.gz.asc" "https://classic.yarnpkg.com/downloads/${ASDF_INSTALL_VERSION}/yarn-v${ASDF_INSTALL_VERSION}.tar.gz.asc"
 
   # Download and import signing key
-  curl -sSL "https://dl.yarnpkg.com/debian/pubkey.gpg" | GNUPGHOME="$(asdf_yarn_keyring)" gpg --import
+  curl -sSL "https://dl.yarnpkg.com/debian/pubkey.gpg" | GNUPGHOME="$(asdf_yarn_v1_keyring)" gpg --import
 }
 
-asdf_yarn_download() {
+asdf_yarn_v1_download() {
   if [ -x "$(which wget)" ]; then
-    asdf_yarn_download_wget
+    asdf_yarn_v1_download_wget
   else
     if [ -x "$(which curl)" ]; then
-      asdf_yarn_download_curl
+      asdf_yarn_v1_download_curl
     fi
   fi
 }
 
-asdf_yarn_install() {
+asdf_yarn_v1_install() {
   local ASDF_YARN_DIR="$(mktemp -d -t asdf-yarn-XXXXXXX)"
 
   (
     cd "${ASDF_YARN_DIR}"
 
-    asdf_yarn_download
+    asdf_yarn_v1_download
 
     # Verify archive signature
-    GNUPGHOME="$(asdf_yarn_keyring)" gpg --verify "yarn-v${ASDF_INSTALL_VERSION}.tar.gz.asc" "yarn-v${ASDF_INSTALL_VERSION}.tar.gz"
+    GNUPGHOME="$(asdf_yarn_v1_keyring)" gpg --verify "yarn-v${ASDF_INSTALL_VERSION}.tar.gz.asc" "yarn-v${ASDF_INSTALL_VERSION}.tar.gz"
 
     # Extract archive
     tar xzf "yarn-v${ASDF_INSTALL_VERSION}.tar.gz" --strip-components=1 --no-same-owner
@@ -79,6 +79,44 @@ asdf_yarn_install() {
 
   # Finish the installation
   mv "${ASDF_YARN_DIR}" "${ASDF_INSTALL_PATH}"
+}
+
+asdf_yarn_v2_plus_install() {
+  local ASDF_YARN_DIR="$(mktemp -d -t asdf-yarn-XXXXXXX)"
+
+  (
+    cd "${ASDF_YARN_DIR}"
+
+    if [ -x "$(which wget)" ]; then
+      wget -O yarn "https://repo.yarnpkg.com/${ASDF_INSTALL_VERSION}/packages/yarnpkg-cli/bin/yarn.js"
+    else
+      if [ -x "$(which curl)" ]; then
+        curl  -sSL -o yarn "https://repo.yarnpkg.com/${ASDF_INSTALL_VERSION}/packages/yarnpkg-cli/bin/yarn.js"
+      fi
+    fi
+  )
+
+  if [ -d "${ASDF_INSTALL_PATH}" ]; then
+    # Remove existing install directory
+    rm -fR "${ASDF_INSTALL_PATH}"
+  fi
+
+  # Create parent directory, if necessary
+  mkdir -p "$(dirname "${ASDF_INSTALL_PATH}")"
+
+  # Finish the installation
+  chmod +x "${ASDF_YARN_DIR}/yarn"
+  mkdir -p "${ASDF_INSTALL_PATH}/bin"
+  mv "${ASDF_YARN_DIR}/yarn" "${ASDF_INSTALL_PATH}/bin/yarn"
+}
+
+asdf_yarn_install(){
+  local MAJOR_VERSION="$(printf %.1s $ASDF_INSTALL_VERSION)"
+  if [ "$MAJOR_VERSION" = "1" ]; then
+    asdf_yarn_v1_install
+  else
+    asdf_yarn_v2_plus_install
+  fi
 }
 
 [ "${ASDF_INSTALL_TYPE}" == 'ref' ] && asdf_yarn_fail "This plugin does not support installing by ref."

--- a/bin/list-all
+++ b/bin/list-all
@@ -3,10 +3,17 @@
 set -o nounset -o pipefail -o errexit
 IFS=$'\t\n'
 
-git ls-remote --refs --tags "https://github.com/yarnpkg/yarn.git" \
+VERSIONS_CLASSIC="$(git ls-remote --refs --tags "https://github.com/yarnpkg/yarn.git" \
 | sed -E 's|^.+refs/tags/||g' \
 | grep -E '^v' \
 | sort --version-sort \
 | sed -E 's|^v||g' \
 | grep -Ev '^0\.' \
-| xargs
+| xargs)"
+
+VERSIONS_BERRY="$(git ls-remote --refs --tags "https://github.com/yarnpkg/berry.git" \
+| grep '@yarnpkg/cli' \
+| sed -E 's|^.+refs/tags/@yarnpkg/cli/||g' \
+| xargs)"
+
+echo "$VERSIONS_CLASSIC $VERSIONS_BERRY"


### PR DESCRIPTION
what i did:
- renamed methods for v1
- added asdf_yarn_v2_plus_install and asdf_yarn_install with simple v1/v2+ switch
  - based on where [corepack](https://nodejs.org/api/corepack.html) gets yarn: https://github.com/nodejs/corepack/blob/a05aec69ff6a8f9a523f9b34e32ba6332d0ce4de/config.json#L135
  - there is no signature for js file, so nothing to verify
  - need to `chmod +x` downloaded file
- added v2+ versions to list-all output 

list-all output. Not sure if should filter out release candidates from list
<img width="1032" alt="316260769-7371fdc2-34d7-44c8-8e16-f4753d2daf53" src="https://github.com/mise-plugins/asdf-yarn/assets/690135/ee7aa068-c10e-4bf4-8d4d-59b466746f86">

Any feedback is welcomed and appreciated 🙇