### PR TITLE
Get rid of asdf mentions and add update instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# asdf-yarn
+# mise-yarn
 
-Yarn plugin for the [asdf][1] version manager.
+Yarn plugin for the [mise][1] version manager.
 
 > 💡 **Note:** This plugin validates package authenticity via [`gpg`][2] only for yarn v1.
 > v2 and later versions are downloaded as single js file which doesn't have any signatures
@@ -13,9 +13,8 @@ If one of the commands needed is unavailable, it will let you know.
 ## Installing
 
 ```
-asdf plugin-add yarn
-asdf install yarn latest
+mise plugin i yarn
 ```
 
-[1]: https://asdf-vm.com/
+[1]: https://mise.jdx.dev/
 [2]: https://www.openpgp.org/

--- a/README.md
+++ b/README.md
@@ -18,3 +18,41 @@ mise plugin i yarn
 
 [1]: https://mise.jdx.dev/
 [2]: https://www.openpgp.org/
+
+## Migration from twuni/asdf-yarn
+
+### Issue with yarn_old
+If you can't update plugin like this
+```bash
+$ mise plugins update yarn
+mise plugin:yarn is a symlink, not updating
+```
+
+Try removing both yarn and yarn_old
+```bash
+$ mise plugins rm yarn
+$ mise plugins rm yarn_old
+```
+
+And then try to install newer version
+```bash
+$ mise plugins i yarn
+mise plugin:yarn ✓ https://github.com/mise-plugins/asdf-yarn.git#somehash
+```
+
+if instead it outputs that it still installs from `twuni/asdf-yarn` like
+``` bash
+mise plugin:yarn ✓ https://github.com/twuni/asdf-yarn.git#somehash
+```
+
+then your registry is still not updated. You can set it to update more frequently (atm there is no command in mise to force update registry) and try to reinstall
+```bash
+$ mise settings set plugin_autoupdate_last_check_duration 1h
+$ mise plugins rm yarn
+$ mise plugins i yarn
+```
+
+it should output
+```bash
+mise plugin:yarn ✓ https://github.com/mise-plugins/asdf-yarn.git#somehash
+```


### PR DESCRIPTION
- replaced asdf with mise in README
- added instructions on plugin update
  - no idea where yarn_old plugin is coming from. Might worth it to add some logic in mise itself for handling this type of updates. I assume nobody will get automatic update of asdf-yarn because of this yarn_old thingy
  - mise doesn't have a command for re-fetching registry. So i kinda hacked it by setting refresh interval to 1h. Not sure why default setting is 7d. Would it make sense to add command to re-fetch registry? I can try to implement it