### PR TITLE
Dont require gpg for yarn v2+

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -55,7 +55,7 @@ asdf_yarn_v1_install() {
   { [ -x "$(which tar)" ] && [ -x "$(which gpg)" ]; } || asdf_yarn_fail "Missing one or more of the following dependencies: tar, gpg"
 
   local ASDF_YARN_DIR
-  ASDF_DATA_DIR="$(mktemp -d -t asdf-yarn-XXXXXXX)"
+  ASDF_YARN_DIR="$(mktemp -d -t asdf-yarn-XXXXXXX)"
 
   (
     cd "${ASDF_YARN_DIR}"

--- a/bin/install
+++ b/bin/install
@@ -52,6 +52,8 @@ asdf_yarn_v1_download() {
 }
 
 asdf_yarn_v1_install() {
+  { [ -x "$(which tar)" ] && [ -x "$(which gpg)" ]; } || asdf_yarn_fail "Missing one or more of the following dependencies: tar, gpg"
+
   local ASDF_YARN_DIR
   ASDF_DATA_DIR="$(mktemp -d -t asdf-yarn-XXXXXXX)"
 
@@ -126,6 +128,5 @@ asdf_yarn_install() {
 [ -z "${ASDF_INSTALL_VERSION}" ] && asdf_yarn_fail "Unspecified install version."
 [ -z "${ASDF_INSTALL_PATH}" ] && asdf_yarn_fail "No installation directory was provided. Are you running this command via asdf? Try running 'asdf install yarn <version>'"
 [ -x "$(which wget)" ] || [ -x "$(which curl)" ] || asdf_yarn_fail "Missing one of either of the following dependencies: wget, curl"
-{ [ -x "$(which tar)" ] && [ -x "$(which gpg)" ]; } || asdf_yarn_fail "Missing one or more of the following dependencies: tar, gpg"
 
 asdf_yarn_install "$@"


### PR DESCRIPTION
- also fixed copypaste error from https://github.com/mise-plugins/asdf-yarn/commit/872c297db7f83852e23767c57907ba894c52bb29#diff-f9746898bdf5ee311b5c55bc0b6d8c64901f52940c591089b3bfbda5f5b26c8aL55

## evidence
v4 installs without gpg
<img width="646" alt="Screenshot 2024-04-10 at 18 29 50" src="https://github.com/mise-plugins/asdf-yarn/assets/690135/69405d21-35b0-4475-ba3f-7f6e31d4b704">

v1 can't install without gpg
<img width="646" alt="Screenshot 2024-04-10 at 18 30 36" src="https://github.com/mise-plugins/asdf-yarn/assets/690135/54bb9831-3cdc-4243-b980-8e1ba4e0236e">

v1 installs with gpg (installing 1.22.19 because 1.22.20 and later [doesn't have `.asc` file)](https://github.com/yarnpkg/yarn/releases/)
<img width="816" alt="Screenshot 2024-04-10 at 18 31 37" src="https://github.com/mise-plugins/asdf-yarn/assets/690135/79cf4558-aca3-4b8e-9896-f48a03f3c446">
<img width="816" alt="Screenshot 2024-04-10 at 18 33 14" src="https://github.com/mise-plugins/asdf-yarn/assets/690135/9f172944-9786-483f-a666-cfafec326c0f">
