### PR TITLE
drop wget support

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -19,18 +19,7 @@ asdf_yarn_v1_keyring() {
   echo "${YARN_KEYRING}"
 }
 
-asdf_yarn_v1_download_wget() {
-  # Download archive
-  wget -O "yarn-v${ASDF_INSTALL_VERSION}.tar.gz" "https://classic.yarnpkg.com/downloads/${ASDF_INSTALL_VERSION}/yarn-v${ASDF_INSTALL_VERSION}.tar.gz"
-
-  # Download archive signature
-  wget -O "yarn-v${ASDF_INSTALL_VERSION}.tar.gz.asc" "https://classic.yarnpkg.com/downloads/${ASDF_INSTALL_VERSION}/yarn-v${ASDF_INSTALL_VERSION}.tar.gz.asc"
-
-  # Download and import signing key
-  wget -q -O - "https://dl.yarnpkg.com/debian/pubkey.gpg" | GNUPGHOME="$(asdf_yarn_v1_keyring)" gpg --import
-}
-
-asdf_yarn_v1_download_curl() {
+asdf_yarn_v1_download() {
   # Download archive
   curl -sSL -o "yarn-v${ASDF_INSTALL_VERSION}.tar.gz" "https://classic.yarnpkg.com/downloads/${ASDF_INSTALL_VERSION}/yarn-v${ASDF_INSTALL_VERSION}.tar.gz"
 
@@ -39,16 +28,6 @@ asdf_yarn_v1_download_curl() {
 
   # Download and import signing key
   curl -sSL "https://dl.yarnpkg.com/debian/pubkey.gpg" | GNUPGHOME="$(asdf_yarn_v1_keyring)" gpg --import
-}
-
-asdf_yarn_v1_download() {
-  if [ -x "$(which wget)" ]; then
-    asdf_yarn_v1_download_wget
-  else
-    if [ -x "$(which curl)" ]; then
-      asdf_yarn_v1_download_curl
-    fi
-  fi
 }
 
 asdf_yarn_v1_install() {
@@ -91,13 +70,7 @@ asdf_yarn_v2_plus_install() {
   (
     cd "${ASDF_YARN_DIR}"
 
-    if [ -x "$(which wget)" ]; then
-      wget -O yarn "https://repo.yarnpkg.com/${ASDF_INSTALL_VERSION}/packages/yarnpkg-cli/bin/yarn.js"
-    else
-      if [ -x "$(which curl)" ]; then
-        curl -sSL -o yarn "https://repo.yarnpkg.com/${ASDF_INSTALL_VERSION}/packages/yarnpkg-cli/bin/yarn.js"
-      fi
-    fi
+    curl -sSL -o yarn "https://repo.yarnpkg.com/${ASDF_INSTALL_VERSION}/packages/yarnpkg-cli/bin/yarn.js"
   )
 
   if [ -d "${ASDF_INSTALL_PATH}" ]; then
@@ -127,6 +100,6 @@ asdf_yarn_install() {
 [ "${ASDF_INSTALL_TYPE}" == 'ref' ] && asdf_yarn_fail "This plugin does not support installing by ref."
 [ -z "${ASDF_INSTALL_VERSION}" ] && asdf_yarn_fail "Unspecified install version."
 [ -z "${ASDF_INSTALL_PATH}" ] && asdf_yarn_fail "No installation directory was provided. Are you running this command via asdf? Try running 'asdf install yarn <version>'"
-[ -x "$(which wget)" ] || [ -x "$(which curl)" ] || asdf_yarn_fail "Missing one of either of the following dependencies: wget, curl"
+[ -x "$(which curl)" ] || asdf_yarn_fail "Missing following dependency: curl"
 
 asdf_yarn_install "$@"


### PR DESCRIPTION
- don't want to keep supporting 2 ways of download
- curl should be on every machine already and it is required for asdf (not required for mise though)