### PR TITLE
Ability to skip gpg verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,20 @@ mise plugin i yarn
 mise plugin up yarn
 ```
 
-# Development
+## Development
 
 This repo has github workflows which check linting and formatting of code in `bin` folder.
 
 To lint code run `make lint` (note: requires `shellcheck` to be installed)
 
 To check formatting run `make format-check` (requires `shfmt` to be installed) and to format code run `make fmt`
+
+## yarn v1 missing signatures
+
+[Latest v1 releases](https://github.com/yarnpkg/yarn/releases/) (`1.22.22`, `1.22.21`, `1.22.20`) don't have signature files (`.asc`) which makes it impossible to install these versions (gpg signature verification doesn't pass). They say "we're working on fixing this" but issue persists since Nov 14, 2023 (release of 1.22.20)
+
+To be able to install those you can use `MISE_YARN_SKIP_GPG` env var
+
+```shell
+MISE_YARN_SKIP_GPG=true mise install yarn@1.22.22
+```

--- a/bin/install
+++ b/bin/install
@@ -23,22 +23,26 @@ asdf_yarn_v1_download_wget() {
   # Download archive
   wget -O "yarn-v${ASDF_INSTALL_VERSION}.tar.gz" "https://classic.yarnpkg.com/downloads/${ASDF_INSTALL_VERSION}/yarn-v${ASDF_INSTALL_VERSION}.tar.gz"
 
-  # Download archive signature
-  wget -O "yarn-v${ASDF_INSTALL_VERSION}.tar.gz.asc" "https://classic.yarnpkg.com/downloads/${ASDF_INSTALL_VERSION}/yarn-v${ASDF_INSTALL_VERSION}.tar.gz.asc"
+  if [ -z ${MISE_YARN_SKIP_GPG+false} ]; then
+    # Download archive signature
+    wget -O "yarn-v${ASDF_INSTALL_VERSION}.tar.gz.asc" "https://classic.yarnpkg.com/downloads/${ASDF_INSTALL_VERSION}/yarn-v${ASDF_INSTALL_VERSION}.tar.gz.asc"
 
-  # Download and import signing key
-  wget -q -O - "https://dl.yarnpkg.com/debian/pubkey.gpg" | GNUPGHOME="$(asdf_yarn_v1_keyring)" gpg --import
+    # Download and import signing key
+    wget -q -O - "https://dl.yarnpkg.com/debian/pubkey.gpg" | GNUPGHOME="$(asdf_yarn_v1_keyring)" gpg --import
+  fi
 }
 
 asdf_yarn_v1_download_curl() {
   # Download archive
   curl -sSL -o "yarn-v${ASDF_INSTALL_VERSION}.tar.gz" "https://classic.yarnpkg.com/downloads/${ASDF_INSTALL_VERSION}/yarn-v${ASDF_INSTALL_VERSION}.tar.gz"
 
-  # Download archive signature
-  curl -sSL -o "yarn-v${ASDF_INSTALL_VERSION}.tar.gz.asc" "https://classic.yarnpkg.com/downloads/${ASDF_INSTALL_VERSION}/yarn-v${ASDF_INSTALL_VERSION}.tar.gz.asc"
+  if [ -z ${MISE_YARN_SKIP_GPG+false} ]; then
+    # Download archive signature
+    curl -sSL -o "yarn-v${ASDF_INSTALL_VERSION}.tar.gz.asc" "https://classic.yarnpkg.com/downloads/${ASDF_INSTALL_VERSION}/yarn-v${ASDF_INSTALL_VERSION}.tar.gz.asc"
 
-  # Download and import signing key
-  curl -sSL "https://dl.yarnpkg.com/debian/pubkey.gpg" | GNUPGHOME="$(asdf_yarn_v1_keyring)" gpg --import
+    #Download and import signing key
+    curl -sSL "https://dl.yarnpkg.com/debian/pubkey.gpg" | GNUPGHOME="$(asdf_yarn_v1_keyring)" gpg --import
+  fi
 }
 
 asdf_yarn_v1_download() {
@@ -52,7 +56,11 @@ asdf_yarn_v1_download() {
 }
 
 asdf_yarn_v1_install() {
-  { [ -x "$(which tar)" ] && [ -x "$(which gpg)" ]; } || asdf_yarn_fail "Missing one or more of the following dependencies: tar, gpg"
+  [ -x "$(which tar)" ] || asdf_yarn_fail "Missing following dependency: tar"
+
+  if [ -z ${MISE_YARN_SKIP_GPG+false} ]; then
+    [ -x "$(which gpg)" ] || asdf_yarn_fail "Missing following dependency: gpg"
+  fi
 
   local ASDF_YARN_DIR
   ASDF_YARN_DIR="$(mktemp -d -t asdf-yarn-XXXXXXX)"
@@ -62,8 +70,10 @@ asdf_yarn_v1_install() {
 
     asdf_yarn_v1_download
 
-    # Verify archive signature
-    GNUPGHOME="$(asdf_yarn_v1_keyring)" gpg --verify "yarn-v${ASDF_INSTALL_VERSION}.tar.gz.asc" "yarn-v${ASDF_INSTALL_VERSION}.tar.gz"
+    if [ -z ${MISE_YARN_SKIP_GPG+false} ]; then
+      # Verify archive signature
+      GNUPGHOME="$(asdf_yarn_v1_keyring)" gpg --verify "yarn-v${ASDF_INSTALL_VERSION}.tar.gz.asc" "yarn-v${ASDF_INSTALL_VERSION}.tar.gz"
+    fi
 
     # Extract archive
     tar xzf "yarn-v${ASDF_INSTALL_VERSION}.tar.gz" --strip-components=1 --no-same-owner


### PR DESCRIPTION
[Latest v1 releases](https://github.com/yarnpkg/yarn/releases/) (`1.22.22`, `1.22.21`, `1.22.20`) don't have signature files (`.asc`) which makes it impossible to install these versions (gpg signature verification doesn't pass). They say "we're working on fixing this" but issue persists since Nov 14, 2023 (release of 1.22.20)

There is also an issue in original repo https://github.com/twuni/asdf-yarn/issues/33

## evidence
skipping gpg verification (curl)
<img width="640" alt="Screenshot 2024-04-10 at 19 54 55" src="https://github.com/mise-plugins/asdf-yarn/assets/690135/66f01094-0a3f-43bc-8c02-30488b859138">

skipping gpg verification (wget with --no-verbose added only for test to shorten output)
<img width="724" alt="Screenshot 2024-04-10 at 21 01 11" src="https://github.com/mise-plugins/asdf-yarn/assets/690135/cab1aebb-46dd-4b43-8189-3704d42c9712">

gpg still required if no env var set
<img width="640" alt="Screenshot 2024-04-10 at 19 54 23" src="https://github.com/mise-plugins/asdf-yarn/assets/690135/2397046c-7dc0-4ea7-9232-e864700dcf0b">

latest version install fails without flag (curl)
<img width="640" alt="Screenshot 2024-04-10 at 19 51 25" src="https://github.com/mise-plugins/asdf-yarn/assets/690135/d64b01c7-3c05-4b71-8dc3-3bcd8c8156ba">

latest version install fails without flag (wget with --no-verbose added only for test to shorten output)
<img width="682" alt="Screenshot 2024-04-10 at 21 00 57" src="https://github.com/mise-plugins/asdf-yarn/assets/690135/066b8198-eed7-4183-b0e1-570c9fd29a45">

